### PR TITLE
Added closing backtick to DELETE query

### DIFF
--- a/src/SessionHandler.php
+++ b/src/SessionHandler.php
@@ -86,7 +86,7 @@ final class SessionHandler implements \SessionHandlerInterface
     
     public function destroy($id)
     {
-        $sql = "DELETE FROM `" . $this->dbTable . " WHERE `id` = '" . $id . "'";
+        $sql = "DELETE FROM `" . $this->dbTable . "` WHERE `id` = '" . $id . "'";
         return $this->dbConnection->query($sql);
     }
     


### PR DESCRIPTION
The closing backtick was missing in the MySQL query. Calling the destroy() method would throw the following error on execution: "Incorrect table name 'my_session_table where '" and, if uncaught, the session data would remain in the session table.