### PR TITLE
Renamed column to correct column name in gc() method query

### DIFF
--- a/src/SessionHandler.php
+++ b/src/SessionHandler.php
@@ -94,7 +94,7 @@ final class SessionHandler implements \SessionHandlerInterface
     public function gc($maxlifetime)
     {
         $sql = sprintf(
-            "DELETE FROM %s WHERE `timestamp` < '%s'", 
+            "DELETE FROM %s WHERE `modified_timestamp` < '%s'", 
             $this->dbTable, 
             time() - intval($maxlifetime)
         );


### PR DESCRIPTION
The dbTable does not have a 'timestamp' column. This seems to be a remnant from previous commits. The column name should be 'modified_timestamp'.